### PR TITLE
Fix NPE when starting a new order

### DIFF
--- a/src/main/java/am/sfl/cafeShushan/controller/LoginController.java
+++ b/src/main/java/am/sfl/cafeShushan/controller/LoginController.java
@@ -79,7 +79,8 @@ public class LoginController {
         table.setTableStatus(TableStatus.BUSY);
         tableService.save(table);
      Order order = tableService.getOpenOrder(table);
-      if (order ==null){
+      if (order == null) {
+          order = new Order();
           order.setStatus("open");
           order.setTable(table);
           order.setProductInOrder(new ProductInOrder());


### PR DESCRIPTION
## Summary
- prevent `NullPointerException` when creating an order on busy table

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887f47af034832d81cb126e7eacc45e